### PR TITLE
fix:使用MariaDB无法获取数据表的兼容性问题

### DIFF
--- a/ruoyi-common/ruoyi-common-mybatis/src/main/java/org/dromara/common/mybatis/enums/DataBaseType.java
+++ b/ruoyi-common/ruoyi-common-mybatis/src/main/java/org/dromara/common/mybatis/enums/DataBaseType.java
@@ -31,7 +31,12 @@ public enum DataBaseType {
     /**
      * SQL Server
      */
-    SQL_SERVER("Microsoft SQL Server");
+    SQL_SERVER("Microsoft SQL Server"),
+
+    /**
+     * MariaDB
+     */
+    MARIA_DB("MariaDB");
 
     private final String type;
 

--- a/ruoyi-common/ruoyi-common-mybatis/src/main/java/org/dromara/common/mybatis/helper/DataBaseHelper.java
+++ b/ruoyi-common/ruoyi-common-mybatis/src/main/java/org/dromara/common/mybatis/helper/DataBaseHelper.java
@@ -41,7 +41,7 @@ public class DataBaseHelper {
     }
 
     public static boolean isMySql() {
-        return DataBaseType.MY_SQL == getDataBaseType();
+        return DataBaseType.MY_SQL == getDataBaseType() || DataBaseType.MARIA_DB == getDataBaseType();
     }
 
     public static boolean isOracle() {


### PR DESCRIPTION
### 更改目的
当数据源使用MariaDB及`driverClassName: org.mariadb.jdbc.Driver`的时候无法正常使用代码生成功能原因是查询数据库表列表失败
### 改动逻辑
Mysql和MariaDB是同源的，即
![image](https://github.com/dromara/RuoYi-Vue-Plus/assets/93933896/aa712614-9a2e-4b2b-9288-a54048e503f3)
在@org.dromara.common.mybatis.helper.DataBaseHelper
将MariaDB判断为走Mysql的逻辑即可
### 测试
修改后正常查询到数据库列表，正常使用代码生成功能