### PR TITLE
修复服务端并未对返回数据加密问题

### DIFF
--- a/ruoyi-admin/src/main/java/org/dromara/web/controller/AuthController.java
+++ b/ruoyi-admin/src/main/java/org/dromara/web/controller/AuthController.java
@@ -178,7 +178,7 @@ public class AuthController {
     /**
      * 用户注册
      */
-    @ApiEncrypt
+    @ApiEncrypt(response = true)
     @PostMapping("/register")
     public R<Void> register(@Validated @RequestBody RegisterBody user) {
         if (!configService.selectRegisterEnabled(user.getTenantId())) {

--- a/ruoyi-admin/src/main/java/org/dromara/web/controller/AuthController.java
+++ b/ruoyi-admin/src/main/java/org/dromara/web/controller/AuthController.java
@@ -79,7 +79,7 @@ public class AuthController {
      * @param body 登录信息
      * @return 结果
      */
-    @ApiEncrypt
+    @ApiEncrypt(response = true)
     @PostMapping("/login")
     public R<LoginVo> login(@RequestBody String body) {
         LoginBody loginBody = JsonUtils.parseObject(body, LoginBody.class);

--- a/ruoyi-common/ruoyi-common-encrypt/src/main/java/org/dromara/common/encrypt/filter/CryptoFilter.java
+++ b/ruoyi-common/ruoyi-common-encrypt/src/main/java/org/dromara/common/encrypt/filter/CryptoFilter.java
@@ -50,8 +50,8 @@ public class CryptoFilter implements Filter {
                 // 请求解密
                 requestWrapper = new DecryptRequestBodyWrapper(servletRequest, properties.getPrivateKey(), properties.getHeaderFlag());
             } else {
-                // 是否有注解，有就报错，没有放行
-                if (ObjectUtil.isNotNull(apiEncrypt)) {
+                // 不存在加密标头，有注解且返回加密为true是直接报错，没有放行
+                if (ObjectUtil.isNotNull(apiEncrypt) && apiEncrypt.response()) {
                     HandlerExceptionResolver exceptionResolver = SpringUtils.getBean("handlerExceptionResolver", HandlerExceptionResolver.class);
                     exceptionResolver.resolveException(
                         servletRequest, servletResponse, null,

--- a/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/controller/system/SysProfileController.java
+++ b/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/controller/system/SysProfileController.java
@@ -86,7 +86,7 @@ public class SysProfileController extends BaseController {
      * @param bo 新旧密码
      */
     @RepeatSubmit
-    @ApiEncrypt
+    @ApiEncrypt(response = true)
     @Log(title = "个人信息", businessType = BusinessType.UPDATE)
     @PutMapping("/updatePwd")
     public R<Void> updatePwd(@Validated @RequestBody SysUserPasswordBo bo) {

--- a/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/controller/system/SysTenantController.java
+++ b/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/controller/system/SysTenantController.java
@@ -82,7 +82,7 @@ public class SysTenantController extends BaseController {
     /**
      * 新增租户
      */
-    @ApiEncrypt
+    @ApiEncrypt(response = true)
     @SaCheckRole(TenantConstants.SUPER_ADMIN_ROLE_KEY)
     @SaCheckPermission("system:tenant:add")
     @Log(title = "租户", businessType = BusinessType.INSERT)

--- a/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/controller/system/SysUserController.java
+++ b/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/controller/system/SysUserController.java
@@ -224,7 +224,7 @@ public class SysUserController extends BaseController {
     /**
      * 重置密码
      */
-    @ApiEncrypt
+    @ApiEncrypt(response = true)
     @SaCheckPermission("system:user:resetPwd")
     @Log(title = "用户管理", businessType = BusinessType.UPDATE)
     @PutMapping("/resetPwd")


### PR DESCRIPTION
修复服务端并未对返回数据加密问题。

虽然CryptoFilter对带ApiEncrypt注解的API有解密操作，但实际由于接口的注解并未response等于true。所以返回的包仍然是非加密的数据。
修复分为3个commit。
6ed559e8d7d0ab21ac9dfb0ab74e8970d3a27b56主要是有ApiEncrypt注解的API在没有response为true，前端也没有加密请求头时没必要一味的Exception。
5f0237a18a7b8e176eff0aac7e80f661a8cb49ba主要修复登录时的返回数据加密。
630df474531d4db4e3789ba50b3bee5d6e7daf3a返回数据为Void。非必要添加response为true。但既然加了注解。避免歧义，所以还是增加了response为true。

附上增加response等于true前后请求的前端打印。
![image](https://github.com/user-attachments/assets/6d104f6e-5faf-48f8-8f1a-c5d3084e86f6)
![image](https://github.com/user-attachments/assets/5ced214e-72be-47fd-9d54-12ee7531aa39)
