### PR TITLE
feat(menu): 更新菜单时自动同步角色菜单关联

### DIFF
--- a/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/service/impl/SysMenuServiceImpl.java
+++ b/ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/service/impl/SysMenuServiceImpl.java
@@ -314,9 +314,24 @@ public class SysMenuServiceImpl implements ISysMenuService {
      * @return 结果
      */
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public int updateMenu(SysMenuBo bo) {
         SysMenu menu = MapstructUtils.convert(bo, SysMenu.class);
-        return baseMapper.updateById(menu);
+        if (menu == null) {
+            return 0;
+        }
+        // 获取修改前的菜单信息
+        SysMenu oldMenu = baseMapper.selectById(menu.getMenuId());
+
+        // 执行更新
+        int result = baseMapper.updateById(menu);
+
+        // 如果parentId发生变化，自动同步角色菜单关联
+        if (result > 0 && oldMenu != null && !oldMenu.getParentId().equals(menu.getParentId())) {
+            syncRoleMenuForParentChange(menu.getMenuId(), menu.getParentId());
+        }
+
+        return result;
     }
 
     /**
@@ -435,6 +450,100 @@ public class SysMenuServiceImpl implements ISysMenuService {
                 recursionFn(list, tChild);
             }
         }
+    }
+
+    /**
+     * 当菜单父级变化时，同步角色菜单关联
+     * 为已分配该菜单的角色自动添加新父菜单及所有祖先菜单的关联
+     *
+     * @param menuId      菜单ID
+     * @param newParentId 新的父菜单ID
+     */
+    private void syncRoleMenuForParentChange(Long menuId, Long newParentId) {
+        // 1. 查询哪些角色已经分配了这个菜单
+        List<SysRoleMenu> roleMenus = roleMenuMapper.selectList(
+            new LambdaQueryWrapper<SysRoleMenu>().eq(SysRoleMenu::getMenuId, menuId)
+        );
+
+        if (CollUtil.isEmpty(roleMenus)) {
+            return;
+        }
+
+        // 2. 获取新父菜单及其所有祖先菜单ID列表
+        List<Long> parentMenuIds = getAllParentMenuIds(newParentId);
+
+        if (CollUtil.isEmpty(parentMenuIds)) {
+            return;
+        }
+
+        // 3. 批量查询已存在的关联关系，避免N+1问题
+        // 收集所有需要检查的roleId（去重）
+        List<Long> roleIds = roleMenus.stream()
+            .map(SysRoleMenu::getRoleId)
+            .distinct()
+            .toList();
+
+        // 一次性查询这些角色和父菜单的所有已存在关联
+        List<SysRoleMenu> existingRelations = roleMenuMapper.selectList(
+            new LambdaQueryWrapper<SysRoleMenu>()
+                .in(SysRoleMenu::getRoleId, roleIds)
+                .in(SysRoleMenu::getMenuId, parentMenuIds)
+        );
+
+        // 将已存在的关联转换为Set，方便快速查找
+        Set<String> existingSet = StreamUtils.toSet(existingRelations,
+            rm -> rm.getRoleId() + ":" + rm.getMenuId());
+
+        // 4. 构建需要新增的关联关系
+        List<SysRoleMenu> newRoleMenus = new ArrayList<>();
+        for (SysRoleMenu roleMenu : roleMenus) {
+            for (Long parentMenuId : parentMenuIds) {
+                String key = roleMenu.getRoleId() + ":" + parentMenuId;
+                // 如果不存在该关联，则添加到新增列表
+                if (!existingSet.contains(key)) {
+                    SysRoleMenu newRoleMenu = new SysRoleMenu();
+                    newRoleMenu.setRoleId(roleMenu.getRoleId());
+                    newRoleMenu.setMenuId(parentMenuId);
+                    newRoleMenus.add(newRoleMenu);
+                }
+            }
+        }
+
+        // 5. 批量插入新的关联关系
+        if (CollUtil.isNotEmpty(newRoleMenus)) {
+            roleMenuMapper.insertBatch(newRoleMenus);
+            log.info("菜单[{}]父级变更，自动为{}个角色添加了{}个父菜单关联", menuId, roleMenus.size(), newRoleMenus.size());
+        }
+    }
+
+    /**
+     * 获取菜单的所有父菜单ID列表（包括自己）
+     *
+     * @param menuId 菜单ID
+     * @return 父菜单ID列表
+     */
+    private List<Long> getAllParentMenuIds(Long menuId) {
+        List<Long> parentIds = new ArrayList<>();
+        if (menuId == null || Constants.TOP_PARENT_ID.equals(menuId)) {
+            return parentIds;
+        }
+
+        // 先添加自己
+        parentIds.add(menuId);
+
+        // 递归查找所有父菜单
+        Long currentId = menuId;
+        while (true) {
+            SysMenuVo menu = baseMapper.selectVoById(currentId);
+            if (menu == null || Constants.TOP_PARENT_ID.equals(menu.getParentId())) {
+                break;
+            }
+
+            currentId = menu.getParentId();
+            parentIds.add(currentId);
+        }
+
+        return parentIds;
     }
 
 }


### PR DESCRIPTION
## 更改目的

**问题描述：**
当管理员在菜单管理中移动菜单（修改菜单的父级目录）时，`sys_role_menu` 表中的角色-菜单关联不会自动更新，导致已分配该菜单的角色无法看到移动后的菜单。管理员需要手动进入每个相关角色的权限配置页面重新勾选菜单，容易遗漏且操作繁琐。

**解决方案：**
实现菜单父级变更时自动同步角色菜单关联的功能，确保角色权限的完整性，无需手动维护。

---

## 改动逻辑

### 核心改动文件
- `ruoyi-modules/ruoyi-system/src/main/java/org/dromara/system/service/impl/SysMenuServiceImpl.java`

### 主要修改点

#### 1. 增强 `updateMenu` 方法
- 添加 `@Transactional` 注解确保事务一致性
- 在更新前保存旧菜单信息用于对比
- 检测 `parentId` 是否发生变化
- 如果变化，调用同步方法自动处理角色关联

#### 2. 新增 `syncRoleMenuForParentChange` 方法
**功能：** 当菜单父级变化时，为已分配该菜单的角色自动添加新父菜单及所有祖先菜单的关联

**实现逻辑：**
1. 查询哪些角色已经分配了这个菜单
2. 获取新父菜单及其所有祖先菜单的ID列表（递归向上查找）
3. **批量查询优化**：一次性查询这些角色和父菜单的所有已存在关联（避免N+1问题）
4. 使用 Set 存储已存在的关联，O(1) 时间复杂度判断
5. 批量插入新的关联关系
6. 记录日志方便追踪

#### 3. 新增 `getAllParentMenuIds` 方法
**功能：** 递归获取菜单的所有父菜单ID列表（包括自己）

**实现逻辑：**
- 从指定菜单开始，逐级向上查找父菜单
- 直到根节点（parentId = 0）为止
- 返回完整的父菜单链ID列表

### 数据安全保障
- 使用事务保证数据一致性
- 只添加不存在的关联，避免重复插入
- 保留原有角色权限，仅补充缺失的父菜单关联

---

## 测试 

### 功能测试

#### ✅ 测试场景：移动菜单到新父目录
**前置条件：**
- 菜单A（ID: 100）原属于"系统管理"（ID: 1）
- 角色R1、R2、R3 已分配菜单A

**操作步骤：**
1. 将菜单A移动到"组织管理"（ID: 2）下
2. 查看 `sys_role_menu` 表

**预期结果：**
- 角色R1、R2、R3 自动添加了"组织管理"（ID: 2）的关联
- 角色仍能正常访问菜单A

**实际结果：** ✅ 通过